### PR TITLE
Fix renderer

### DIFF
--- a/lighthouse-api.mjs
+++ b/lighthouse-api.mjs
@@ -93,8 +93,6 @@ class LighthouseAPI {
         throw Error('Lighthouse API response: missing lighthouseResult.');
       }
 
-      delete lhr.i18n; // Remove extra cruft.
-
       const crux = {};
       // Firestore cannot save object keys with values of undefined, so make
       // sure to only include each crux key when the API has populated values.

--- a/lighthouse-data.mjs
+++ b/lighthouse-data.mjs
@@ -100,8 +100,6 @@ export async function getFullReport(url) {
 export async function finalizeReport(url, json, replace) {
   const lhr = json.lhr;
 
-  delete lhr.i18n; // remove cruft we don't to store.
-
   // Trim down the LH results to only include category/scores.
   const categories = JSON.parse(JSON.stringify(lhr.categories)); // clone it.
   const lhrSlim = Object.values(categories).map(cat => {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "node --experimental-modules server.mjs",
+    "debug": "node --inspect-brk --experimental-modules server.mjs",
     "deploy": "gcloud app deploy app.yaml --project webdotdevsite",
     "deploy:queue": "gcloud app deploy queue.yaml --project webdotdevsite",
     "deploy:cron": "gcloud app deploy cron.yaml --project webdotdevsite",


### PR DESCRIPTION
When lighthouse-keeper runs an audit, it saves the results in two fashions:
- A full lhr is saved to GCS
- A "slim" lhr is saved to FireStore

In Lighthouse v6 the `i18n` property is needed to render the full report but previously we were deleting it to save space. But since it's only used in the full LHR that's stored in GCS, we don'd need to worry about the space. Also the `i18n` object on these reports doesn't seem to be that big.

**Changes proposed**:
- Don't delete `i18n` as it's used by the report viewer and we already filter it out when we build the `lhrSlim` that gets stored in Firestore.
- Add a `debug` command to package.json to help with quickly debugging the server.